### PR TITLE
Feature/static bundler to instance

### DIFF
--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -9,7 +9,7 @@ for (let key in Contracts.Verbosity) {
     }
 }
 
-const dedupeGlobsKey = "dedupe";
+const DEDUPE_KEY = "dedupe";
 
 export let argv = yargs
     .help("h", "Show help.")
@@ -35,8 +35,8 @@ export let argv = yargs
         choices: verbosityValues,
         default: Contracts.Verbosity[Contracts.Verbosity.Verbose]
     })
-    .array(dedupeGlobsKey)
-    .default(dedupeGlobsKey, [], "[]")
+    .array(DEDUPE_KEY)
+    .default(DEDUPE_KEY, [], "[]")
     .usage("Usage: scss-bundle [options]")
     .string(["c", "e", "d"])
     .argv as Contracts.ArgumentsValues;

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -9,7 +9,7 @@ for (let key in Contracts.Verbosity) {
     }
 }
 
-const dedupeGlobsKey = "dedupeGlobs";
+const dedupeGlobsKey = "dedupe";
 
 export let argv = yargs
     .help("h", "Show help.")

--- a/src/bundle-cli.ts
+++ b/src/bundle-cli.ts
@@ -17,7 +17,7 @@ class BundleCli {
         return {
             Destination: argv.dest,
             Entry: argv.entry,
-            DedupeGlobs: argv.dedupeGlobs,
+            DedupeGlobs: argv.dedupe,
             Verbosity: this.resolveVerbosity(argv.verbosity)
         };
     }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -44,7 +44,7 @@ export class Bundler {
         files: string[],
         dedupeGlobs: string[]
     ): Promise<BundleResult[]> {
-        let resultsPromises = files.map(file => this.Bundle(file, dedupeGlobs));
+        const resultsPromises = files.map(file => this.Bundle(file, dedupeGlobs));
         return await Promise.all(resultsPromises);
     }
 
@@ -90,9 +90,9 @@ export class Bundler {
             if (importName.indexOf(FILE_EXTENSION) === -1) {
                 importName += FILE_EXTENSION;
             }
-            let fullPath = path.resolve(dirname, importName);
+            const fullPath = path.resolve(dirname, importName);
 
-            let importData: ImportData = {
+            const importData: ImportData = {
                 importString: match[0],
                 path: importName,
                 fullPath: fullPath,

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -36,9 +36,7 @@ export class Bundler {
     // Imports dictionary by file
     private importsByFile: { [key: string]: BundleResult[] } = {};
 
-    constructor(private fileRegistry: FileRegistry = {}) {
-
-    }
+    constructor(private fileRegistry: FileRegistry = {}) { }
 
     public async BundleAll(
         files: string[],

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -16,5 +16,5 @@ export interface ArgumentsValues {
     entry: string;
     dest: string;
     verbosity: Verbosity;
-    dedupeGlobs?: string[];
+    dedupe?: string[];
 }

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -16,7 +16,8 @@ export class Launcher {
     public async Bundle() {
         try {
             const fileRegistry: FileRegistry = {};
-            let bundleResult = await Bundler.Bundle(this.config.Entry, this.config.DedupeGlobs, fileRegistry);
+            const bundler = new Bundler(fileRegistry);
+            let bundleResult = await bundler.Bundle(this.config.Entry, this.config.DedupeGlobs);
 
             if (!bundleResult.found) {
                 if (this.config.Verbosity !== Contracts.Verbosity.None) {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -17,7 +17,7 @@ export class Launcher {
         try {
             const fileRegistry: FileRegistry = {};
             const bundler = new Bundler(fileRegistry);
-            let bundleResult = await bundler.Bundle(this.config.Entry, this.config.DedupeGlobs);
+            const bundleResult = await bundler.Bundle(this.config.Entry, this.config.DedupeGlobs);
 
             if (!bundleResult.found) {
                 if (this.config.Verbosity !== Contracts.Verbosity.None) {
@@ -52,7 +52,7 @@ export class Launcher {
 
             await fs.writeFile(this.config.Destination, bundleResult.bundledContent);
 
-            let fullPath = path.resolve(this.config.Destination);
+            const fullPath = path.resolve(this.config.Destination);
             if (this.config.Verbosity === Contracts.Verbosity.Verbose) {
                 console.info(`[Done] Bundled into:${os.EOL}${fullPath}`);
                 console.info(`Total size       : ${prettyBytes(bundleResult.bundledContent.length)}`);
@@ -83,7 +83,7 @@ export class Launcher {
         if (sourceDirectory == null) {
             sourceDirectory = process.cwd();
         }
-        let archyData: archy.Data = {
+        const archyData: archy.Data = {
             label: path.relative(sourceDirectory, bundleResult.filePath)
         };
 


### PR DESCRIPTION
Because #21 introduces breaking changes, it's better to deliver more breaking changes in a single release.
Therefore, static Bundler is now refactored into an instance class.

Solves #23