### PR TITLE
fix: invalid index import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 /* */ 
-module.exports = require('./dist/bundle');
+module.exports = require('./dist/bundler');


### PR DESCRIPTION
It seems that the import of the bundler is not correct right now. The file is called `bundler.js`.

@DovydasNavickas That's the exception I have right now

```
Error: Cannot find module './dist/bundle'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (D:\Dateien\Dokumente\Projects\material2\node_modules\scss-bundle\index.js:2:18)

```