### PR TITLE
fix: content empty when importing dupe

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -197,7 +197,7 @@ export class Bundler {
                     timesUsed != null &&
                     timesUsed > 1) {
                     // Reset content to an empty string to skip it
-                    content = "";
+                    contentToReplace = "";
                     // And indicate that import was deduped
                     currentImport.deduped = true;
                 }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -196,7 +196,7 @@ export class Bundler {
                 if (dedupeFiles.indexOf(imp.fullPath) !== -1 &&
                     timesUsed != null &&
                     timesUsed > 1) {
-                    // Reset content to an empty string to skip it
+                    // Reset content to replace to an empty string to skip it
                     contentToReplace = "";
                     // And indicate that import was deduped
                     currentImport.deduped = true;


### PR DESCRIPTION
Currently when a file `Y` is imported twice from a file `X`. Then the full content of `X` will be empty. The import statement should be just removed, and the content of file `X` should still exist.

Not really 100% sure about it, but this fixes the issue I ran into. 