### PR TITLE
fix(bundler): `dedupeGlobs` in `BundleAll` is not optional

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -41,7 +41,7 @@ export class Bundler {
 
     public async BundleAll(
         files: string[],
-        dedupeGlobs: string[]
+        dedupeGlobs: string[] = []
     ): Promise<BundleResult[]> {
         const resultsPromises = files.map(async file => this.Bundle(file, dedupeGlobs));
         return await Promise.all(resultsPromises);


### PR DESCRIPTION
There is no reason why `dedupeGlobs` shouldn't be optional in `BundleAll` as it is defaulted to `[]` in `Bundle`
https://github.com/alan-agius4/scss-bundle/blob/3a71db34aaae3b7923dc4190948163f9e5c6e623/src/bundler.ts#L50