### PR TITLE
feat: looser import statement regex

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -5,7 +5,7 @@ import * as globs from "globs";
 
 import * as Helpers from "./helpers";
 
-const IMPORT_PATTERN = /@import ['"](.+)['"];/g;
+const IMPORT_PATTERN = /@import\s+['"](.+)['"];/g;
 const COMMENT_PATTERN = /\/\/.*$/gm;
 const MULTILINE_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const FILE_EXTENSION = ".scss";

--- a/tests/cases/__tests__/__snapshots__/whitespace-imports.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/whitespace-imports.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`whitespace-imports 1`] = `
+"$a-variable: green;
+$b-variable: blue;
+
+.class {
+    background-color: $a-variable;
+    color: $b-variable;
+}"
+`;

--- a/tests/cases/whitespace-imports/a.scss
+++ b/tests/cases/whitespace-imports/a.scss
@@ -1,0 +1,1 @@
+$a-variable: green;

--- a/tests/cases/whitespace-imports/b.scss
+++ b/tests/cases/whitespace-imports/b.scss
@@ -1,0 +1,1 @@
+$b-variable: blue;

--- a/tests/cases/whitespace-imports/main.scss
+++ b/tests/cases/whitespace-imports/main.scss
@@ -1,0 +1,7 @@
+@import	"./a.scss";
+@import    "b";
+
+.class {
+    background-color: $a-variable;
+    color: $b-variable;
+}

--- a/tests/cases/whitespace-imports/test-config.json
+++ b/tests/cases/whitespace-imports/test-config.json
@@ -1,0 +1,3 @@
+{
+    "Entry": "main.scss"
+}


### PR DESCRIPTION
Was really scratching my head on this one. The strict format on the regex for pulling out the import statements was causing some imports to be missed.

Offending code with whitespace (someone put that there):
![image](https://user-images.githubusercontent.com/4655972/40683456-a9b90d90-635c-11e8-96c8-c5b7c19dfb0a.png)

```
[Error] There is an error in your styles:
File to import not found or unreadable: animations. on line (1294, 1)
```

I've confirmed this is now working with my local. I wasn't able to run the tests, so I just added to the simple case. It should generate the same as the snapshot.