### PR TITLE
feat: Fall back to `.css` files if no `.scss` file found

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -253,13 +253,20 @@ export class Bundler {
                 importData.fullPath = underscoredFilePath;
                 importData.found = true;
             } catch (underscoreErr) {
-                // If there are any includePaths
-                if (includePaths.length) {
-                    // Resolve fullPath using its first entry
-                    importData.fullPath = path.resolve(includePaths[0], importData.path);
-                    // Try resolving import with the remaining includePaths
-                    const remainingIncludePaths = includePaths.slice(1);
-                    return this.resolveImport(importData, remainingIncludePaths);
+                try {
+                    const cssFallbackFilePath = importData.fullPath.replace(/\.scss/g, ".css");
+                    await fs.access(cssFallbackFilePath);
+                    importData.fullPath = cssFallbackFilePath;
+                    importData.found = true;
+                } catch (cssErr) {
+                    // If there are any includePaths
+                    if (includePaths.length) {
+                        // Resolve fullPath using its first entry
+                        importData.fullPath = path.resolve(includePaths[0], importData.path);
+                        // Try resolving import with the remaining includePaths
+                        const remainingIncludePaths = includePaths.slice(1);
+                        return this.resolveImport(importData, remainingIncludePaths);
+                    }
                 }
             }
         }

--- a/tests/cases/__tests__/__snapshots__/css-fallback.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/css-fallback.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`css-fallback 1`] = `
+".foo {
+    color: red;
+}
+
+"
+`;

--- a/tests/cases/css-fallback/.gitignore
+++ b/tests/cases/css-fallback/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/tests/cases/css-fallback/main.scss
+++ b/tests/cases/css-fallback/main.scss
@@ -1,0 +1,1 @@
+@import "~styles-package/styles";

--- a/tests/cases/css-fallback/node_modules/styles-package/styles.css
+++ b/tests/cases/css-fallback/node_modules/styles-package/styles.css
@@ -1,0 +1,3 @@
+.foo {
+    color: red;
+}

--- a/tests/cases/css-fallback/test-config.json
+++ b/tests/cases/css-fallback/test-config.json
@@ -1,0 +1,3 @@
+{
+    "entry": "main.scss"
+}


### PR DESCRIPTION
In #48, it was noted that all import paths had the `.scss` extension added if not already present. A fix was merged which solved the situation of a `.css` extension being specified, but it did not solve the case where an import is for a `.css` file but does not specify the extension. This change solves that by falling back to looking for `.css` files if a `.scss` file cannot be found.